### PR TITLE
fix: create /logout route

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,12 +3,14 @@
 class Users::SessionsController < Devise::SessionsController
   before_action :configure_sign_in_params, only: [:create]
 
-  skip_before_action :verify_authenticity_token, only: [:backchannel_logout]
+  skip_before_action :verify_authenticity_token, only: [:destroy, :backchannel_logout]
 
   def create
     super
   end
 
+  # This endpoint is also redirected to by EBSCO from eResources to logout the user at /ebsco_logout.
+  # It DOES NOT check for the authenticity token.
   def destroy
     if session[:iss].present?
       # After Keycloak logout, Keycloak will send a POST to "/backchannel_logout" to
@@ -22,6 +24,8 @@ class Users::SessionsController < Devise::SessionsController
     end
   end
 
+  # This endpoint is for Keycloak to invalidate sessions terminated from within Keycloak's admin UI.
+  # It DOES NOT check for the authenticity token.
   def backchannel_logout
     logout_token = params["logout_token"]
     jwt = JWT.decode(logout_token, nil, false)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
   devise_scope(:user) do
     get "sign_in", to: "users/sessions#new", as: :new_user_session
     delete "sign_out", to: "users/sessions#destroy", as: :destroy_user_session
+    get "ebsco_logout", to: "users/sessions#destroy", as: :ebsco_logout
     get "expired_keycloak_logout", to: "users/sessions#expired_keycloak_logout", as: :expired_keycloak_logout
     post "backchannel_logout", to: "users/sessions#backchannel_logout", as: :backchannel_logout
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   devise_scope(:user) do
     get "sign_in", to: "users/sessions#new", as: :new_user_session
     delete "sign_out", to: "users/sessions#destroy", as: :destroy_user_session
-    get "ebsco_logout", to: "users/sessions#destroy", as: :ebsco_logout
+    get "logout", to: "users/sessions#destroy", as: :logout
     get "expired_keycloak_logout", to: "users/sessions#expired_keycloak_logout", as: :expired_keycloak_logout
     post "backchannel_logout", to: "users/sessions#backchannel_logout", as: :backchannel_logout
   end

--- a/spec/requests/logout_spec.rb
+++ b/spec/requests/logout_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe "Logout" do
     expect(request).to redirect_to("#{iss}/protocol/openid-connect/logout?id_token_hint=#{id_token}&post_logout_redirect_uri=#{root_url}")
   end
 
+  context "when navigated to /logout" do
+    it "redirects to Keycloak's logout URL" do
+      id_token = auth_hash.extra.id_token
+      iss = auth_hash.extra.raw_info.iss
+
+      session = {iss: iss, id_token: id_token}
+
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(::Users::SessionsController).to receive(:session).and_return(session)
+      # rubocop:enable RSpec/AnyInstance
+
+      get logout_url
+      expect(flash[:notice]).to eq I18n.t("devise.sessions.signed_out")
+      expect(request).to redirect_to("#{iss}/protocol/openid-connect/logout?id_token_hint=#{id_token}&post_logout_redirect_uri=#{root_url}")
+    end
+  end
+
   context "when Keycloak performs backchannel logout" do
     let(:logout_token) { IO.read("spec/files/auth/logout_token.txt") }
     let(:session_id) do


### PR DESCRIPTION
A GET route named `/logout` that can be redirected to by external applications/websites to trigger the current user to be logged out.