### PR TITLE
fix: eResources logout route

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,14 +3,13 @@
 class Users::SessionsController < Devise::SessionsController
   before_action :configure_sign_in_params, only: [:create]
 
-  skip_before_action :verify_authenticity_token, only: [:destroy, :backchannel_logout]
+  skip_before_action :verify_authenticity_token, only: [:backchannel_logout]
 
   def create
     super
   end
 
-  # This endpoint is also redirected to by EBSCO from eResources to logout the user at /ebsco_logout.
-  # It DOES NOT check for the authenticity token.
+  # This route can also be redirected to by external applications to logout the user via /logout.
   def destroy
     if session[:iss].present?
       # After Keycloak logout, Keycloak will send a POST to "/backchannel_logout" to

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,12 +3,14 @@
 class Users::SessionsController < Devise::SessionsController
   before_action :configure_sign_in_params, only: [:create]
 
-  skip_before_action :verify_authenticity_token, only: [:backchannel_logout]
+  skip_before_action :verify_authenticity_token, only: [:destroy, :backchannel_logout]
 
   def create
     super
   end
 
+  # This endpoint is also redirected to by EBSCO from eResources to logout the user at /ebsco_logout.
+  # It DOES NOT check for the authenticity token.
   def destroy
     if session[:iss].present?
       # After Keycloak logout, Keycloak will send a POST to "/backchannel_logout" to
@@ -22,6 +24,8 @@ class Users::SessionsController < Devise::SessionsController
     end
   end
 
+  # This endpoint is for Keycloak to invalidate sessions terminated from within Keycloak's admin UI.
+  # It DOES NOT check for the authenticity token.
   def backchannel_logout
     logout_token = params["logout_token"]
     jwt = JWT.decode(logout_token, nil, false)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@
 #  user_catalogue_shared_omniauth_callback GET|POST /users/auth/catalogue_shared/callback(.:format)                                                   users/omniauth_callbacks#catalogue_shared
 #                         new_user_session GET      /sign_in(.:format)                                                                                users/sessions#new
 #                     destroy_user_session DELETE   /sign_out(.:format)                                                                               users/sessions#destroy
+#                                   logout GET      /logout(.:format)                                                                                 users/sessions#destroy
 #                  expired_keycloak_logout GET      /expired_keycloak_logout(.:format)                                                                users/sessions#expired_keycloak_logout
 #                       backchannel_logout POST     /backchannel_logout(.:format)                                                                     users/sessions#backchannel_logout
 #            rails_postmark_inbound_emails POST     /rails/action_mailbox/postmark/inbound_emails(.:format)                                           action_mailbox/ingresses/postmark/inbound_emails#create
@@ -54,7 +55,7 @@ Rails.application.routes.draw do
   devise_scope(:user) do
     get "sign_in", to: "users/sessions#new", as: :new_user_session
     delete "sign_out", to: "users/sessions#destroy", as: :destroy_user_session
-    get "ebsco_logout", to: "users/sessions#destroy", as: :ebsco_logout
+    get "logout", to: "users/sessions#destroy", as: :logout
     get "expired_keycloak_logout", to: "users/sessions#expired_keycloak_logout", as: :expired_keycloak_logout
     post "backchannel_logout", to: "users/sessions#backchannel_logout", as: :backchannel_logout
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
   devise_scope(:user) do
     get "sign_in", to: "users/sessions#new", as: :new_user_session
     delete "sign_out", to: "users/sessions#destroy", as: :destroy_user_session
+    get "ebsco_logout", to: "users/sessions#destroy", as: :ebsco_logout
     get "expired_keycloak_logout", to: "users/sessions#expired_keycloak_logout", as: :expired_keycloak_logout
     post "backchannel_logout", to: "users/sessions#backchannel_logout", as: :backchannel_logout
   end

--- a/spec/requests/logout_spec.rb
+++ b/spec/requests/logout_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe "Logout" do
     expect(request).to redirect_to("#{iss}/protocol/openid-connect/logout?id_token_hint=#{id_token}&post_logout_redirect_uri=#{root_url}")
   end
 
+  context "when navigated to /logout" do
+    it "redirects to Keycloak's logout URL" do
+      id_token = auth_hash.extra.id_token
+      iss = auth_hash.extra.raw_info.iss
+
+      session = {iss: iss, id_token: id_token}
+
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(::Users::SessionsController).to receive(:session).and_return(session)
+      # rubocop:enable RSpec/AnyInstance
+
+      get logout_url
+      expect(flash[:notice]).to eq I18n.t("devise.sessions.signed_out")
+      expect(request).to redirect_to("#{iss}/protocol/openid-connect/logout?id_token_hint=#{id_token}&post_logout_redirect_uri=#{root_url}")
+    end
+  end
+
   context "when Keycloak performs backchannel logout" do
     let(:logout_token) { IO.read("spec/files/auth/logout_token.txt") }
     let(:session_id) do

--- a/spec/requests/logout_spec.rb
+++ b/spec/requests/logout_spec.rb
@@ -2,47 +2,42 @@
 
 require "rails_helper"
 
-RSpec.describe "Logout" do
-  include Devise::Test::IntegrationHelpers
-
+RSpec.shared_context "with active session" do
   let(:file) { IO.read("spec/files/auth/staff_auth_hash.json") }
   let(:auth_hash) { OmniAuth::AuthHash.new(JSON.parse(file)) }
+  let(:id_token) { auth_hash.extra.id_token }
+  let(:iss) { auth_hash.extra.raw_info.iss }
+  let(:session) do
+    {iss: iss, id_token: id_token}
+  end
 
   before do
     patron = create(:user, :staff)
     sign_in patron
-  end
-
-  it "redirects to Keycloak's logout URL" do
-    id_token = auth_hash.extra.id_token
-    iss = auth_hash.extra.raw_info.iss
-
-    session = {iss: iss, id_token: id_token}
 
     # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(::Users::SessionsController).to receive(:session).and_return(session)
     # rubocop:enable RSpec/AnyInstance
+  end
+end
 
-    delete destroy_user_session_path
+RSpec.shared_examples "logged out" do |action: :delete, path: "destroy_user_session_path"|
+  it "logs out the user" do
+    process(action, send(path))
     expect(flash[:notice]).to eq I18n.t("devise.sessions.signed_out")
     expect(request).to redirect_to("#{iss}/protocol/openid-connect/logout?id_token_hint=#{id_token}&post_logout_redirect_uri=#{root_url}")
   end
+end
+
+RSpec.describe "Logout" do
+  include Devise::Test::IntegrationHelpers
+
+  include_context "with active session"
+
+  it_behaves_like "logged out"
 
   context "when navigated to /logout" do
-    it "redirects to Keycloak's logout URL" do
-      id_token = auth_hash.extra.id_token
-      iss = auth_hash.extra.raw_info.iss
-
-      session = {iss: iss, id_token: id_token}
-
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(::Users::SessionsController).to receive(:session).and_return(session)
-      # rubocop:enable RSpec/AnyInstance
-
-      get logout_url
-      expect(flash[:notice]).to eq I18n.t("devise.sessions.signed_out")
-      expect(request).to redirect_to("#{iss}/protocol/openid-connect/logout?id_token_hint=#{id_token}&post_logout_redirect_uri=#{root_url}")
-    end
+    it_behaves_like "logged out", action: :get, path: :logout_url
   end
 
   context "when Keycloak performs backchannel logout" do


### PR DESCRIPTION
A GET route named /logout that can be redirected to by external applications/websites to trigger the current user to be logged out.