### PR TITLE
fix!(solr): change query params for single document search

### DIFF
--- a/lib/blacklight/solr_cloud.rb
+++ b/lib/blacklight/solr_cloud.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "solr_cloud/version"
-
-module Blacklight
-  module SolrCloud
-    class Error < StandardError; end
-  end
-end

--- a/lib/blacklight/solr_cloud/version.rb
+++ b/lib/blacklight/solr_cloud/version.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Blacklight
-  module SolrCloud
-    VERSION = "0.2.3"
-  end
-end

--- a/spec/lib/nla/solr_cloud/repository_spec.rb
+++ b/spec/lib/nla/solr_cloud/repository_spec.rb
@@ -3,9 +3,9 @@
 require "spec_helper"
 
 require "zk"
-require "blacklight/solr_cloud/repository"
+require "nla/solr_cloud/repository"
 
-RSpec.describe Blacklight::SolrCloud::Repository, type: :api do
+RSpec.describe Nla::SolrCloud::Repository, type: :api do
   subject(:repository) { described_class.new blacklight_config }
 
   let(:connection_config) do
@@ -68,7 +68,7 @@ RSpec.describe Blacklight::SolrCloud::Repository, type: :api do
       IO.read("spec/files/solr_repository/collection1_all_nodes_down.json"))
     expect do
       repository.connection
-    end.to raise_error(Blacklight::SolrCloud::NotEnoughNodes, /There are not enough nodes to handle the request./)
+    end.to raise_error(Nla::SolrCloud::NotEnoughNodes, /There are not enough nodes to handle the request./)
   end
 
   it "chooses another node when leader node is down" do


### PR DESCRIPTION
This allows the use of /select endpoint instead of /get to reduce application errors when a shard leader goes down.

BREAKING CHANGE: Solr repository module changed and single document search no longer uses Blacklight default /get endpoint.

re BLAC-626