### PR TITLE
feat: hide 2FA changes behind feature flag

### DIFF
--- a/app/components/email2fa_alert_component.rb
+++ b/app/components/email2fa_alert_component.rb
@@ -9,7 +9,7 @@ class Email2faAlertComponent < ViewComponent::Base
   end
 
   def render?
-    @status == false
+    ENV["EMAIL_2FA_REGISTRATION_URL"].present? && @status == false
   end
 
   def enable_link

--- a/spec/components/email2fa_alert_component_spec.rb
+++ b/spec/components/email2fa_alert_component_spec.rb
@@ -3,7 +3,20 @@
 require "rails_helper"
 
 RSpec.describe Email2faAlertComponent, type: :component do
+  describe "when feature flag is not enabled" do
+    it "does not render" do
+      render_inline(described_class.new(false, "https://example.com/enable", "https://example.com/help", true))
+
+      expect(page).not_to have_css("#email-2fa-alert")
+    end
+  end
+
   describe "when user has not enabled 2FA" do
+    before do
+      new_env = ENV.to_hash
+      stub_const("ENV", new_env.merge("EMAIL_2FA_REGISTRATION_URL" => "https://dummy.com"))
+    end
+
     context "when user has not dismissed the alert" do
       it "renders" do
         render_inline(described_class.new(false, "https://example.com/enable", "https://example.com/help", nil))

--- a/spec/requests/email2fa_alert_spec.rb
+++ b/spec/requests/email2fa_alert_spec.rb
@@ -6,7 +6,26 @@ RSpec.describe "Email2faAlerts" do
     sign_in patron
   end
 
+  describe "when feature flag is not enabled" do
+    it "returns http success" do
+      # rubocop:disable RSpec/VerifiedDoubles
+      allow(Email2faService).to receive(:new).and_return(double(email_2fa_status: false))
+      # rubocop:enable RSpec/VerifiedDoubles
+
+      get email_2fa_alert_path
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+      expect(response.body).not_to include("Would you like to further secure your NLA user account with Two-factor Authentication (2FA)?")
+    end
+  end
+
   describe "GET /show" do
+    before do
+      new_env = ENV.to_hash
+      stub_const("ENV", new_env.merge("EMAIL_2FA_REGISTRATION_URL" => "https://dummy.com"))
+    end
+
     it "returns http success" do
       # rubocop:disable RSpec/VerifiedDoubles
       allow(Email2faService).to receive(:new).and_return(double(email_2fa_status: false))
@@ -21,6 +40,11 @@ RSpec.describe "Email2faAlerts" do
   end
 
   describe "GET /dismiss" do
+    before do
+      new_env = ENV.to_hash
+      stub_const("ENV", new_env.merge("EMAIL_2FA_REGISTRATION_URL" => "https://dummy.com"))
+    end
+
     it "returns http success" do
       get email_2fa_alert_dismiss_path
 


### PR DESCRIPTION
Prevents the alert from displaying when 2FA env variables aren't defined.