### PR TITLE
feat: disable login buttons during FOLIO update

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,3 +1,5 @@
 <h1>Login</h1>
 
-<%= render "keycloak_login" %>
+<% unless ENV["FOLIO_UPDATE_IN_PROGRESS"] == "true" %>
+  <%= render "keycloak_login" %>
+<% end %>

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -30,4 +30,45 @@ RSpec.describe "Login" do
     expect(page).to have_content(I18n.t("auth.patron.upgrade_text"))
     expect(page).to have_content(I18n.t("auth.patron.upgrade_btn"))
   end
+
+  context "when FOLIO_UPDATE_IN_PROGRESS is `true`" do
+    it "does not render the request button" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("true")
+
+      visit new_user_session_path
+
+      expect(page).not_to have_button(I18n.t("auth.patron.login_btn"))
+    end
+  end
+
+  context "when FOLIO_UPDATE_IN_PROGRESS is `false`" do
+    it "renders the request button" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("false")
+
+      visit new_user_session_path
+
+      expect(page).to have_button(I18n.t("auth.patron.login_btn"))
+    end
+  end
+
+  context "when FOLIO_UPDATE_IN_PROGRESS is defined without a value" do
+    it "renders the request button" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return(nil)
+
+      visit new_user_session_path
+
+      expect(page).to have_button(I18n.t("auth.patron.login_btn"))
+    end
+  end
+
+  context "when FOLIO_UPDATE_IN_PROGRESS is not defined" do
+    it "renders the request button" do
+      visit new_user_session_path
+
+      expect(page).to have_button(I18n.t("auth.patron.login_btn"))
+    end
+  end
 end


### PR DESCRIPTION
Users can still access the login landing page when clicking an eResources link, since they will be prompted to login.
This will just hide all the buttons on that page.